### PR TITLE
Block async

### DIFF
--- a/LISEZMOI.md
+++ b/LISEZMOI.md
@@ -35,10 +35,10 @@ npm install mkimp
 import { MkImp } from "mkimp";
 
 const mkimp = new MkImp({
-  include(loc, from, to) {
+  async include(loc, from, to) {
     return `${loc} de [${from}] à [${to}]`;
   },
-  includeCode(loc, from, to) {
+  async includeCode(loc, from, to) {
     return `${loc} de [${from}] à [${to}]`;
   },
 });
@@ -55,9 +55,9 @@ interface MkImpOptions {
   tabulation?: number; // Nombre d'espaces pour une indentation (par défaut : 4)
   metadata?: Map<string, string>; // Métadonnées à injecter (non écrasées si déjà présentes)
   emojis?: Record<string, EmojiRecord>; // Emojis personnalisés
-  frontMatter?: (content: string) => unknown; // Parseur front matter personnalisé (par défaut : JSON)
-  include?: (location: string, from?: number, to?: number) => string; // Gestion des blocs !INCLUDE
-  includeCode?: (location: string, from?: number, to?: number) => string | undefined; // Gestion des blocs !INCLUDECODE
+  frontMatter?: (content: string) => Promise<unknown>; // Parseur front matter personnalisé (par défaut : JSON)
+  include?: (location: string, from?: number, to?: number) => Promise<string | undefined>; // Gestion des blocs !INCLUDE
+  includeCode?: (location: string, from?: number, to?: number) => Promise<string | undefined>; // Gestion des blocs !INCLUDECODE
   withSection?: boolean; // Grouper les titres par section (par défaut : false)
   renderTarget?: RenderTarget; // Format de rendu ("raw" ou "article")
 }
@@ -78,9 +78,9 @@ type EmojiRecord =
 class MkImp {
   constructor(options?: MkImpOptions);
 
-  ast(markdown: string): RootToken;      // Génère l’AST
-  render(root: RootToken): string;       // Rend en HTML à partir de l’AST
-  parse(markdown: string): string;       // Parse directement le markdown vers du HTML
+  ast(markdown: string): Promise<RootToken>;  // Génère l’AST
+  render(root: RootToken): string;            // Rend en HTML à partir de l’AST
+  parse(markdown: string): Promise<string>;   // Parse directement le markdown vers du HTML
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ npm install mkimp
 import { MkImp } from "mkimp";
 
 const mkimp = new MkImp({
-  include(loc, from, to) {
+  async include(loc, from, to) {
     return `${loc} from [${from}] to [${to}]`;
   },
-  includeCode(loc, from, to) {
+  async includeCode(loc, from, to) {
     return `${loc} from [${from}] to [${to}]`;
   },
 });
@@ -55,9 +55,9 @@ interface MkImpOptions {
   tabulation?: number; // Number of spaces per indentation level (default: 4)
   metadata?: Map<string, string>; // Front matter metadata (won't override existing entries)
   emojis?: Record<string, EmojiRecord>; // Custom emoji definitions
-  frontMatter?: (content: string) => unknown; // Custom front matter parser (default: JSON)
-  include?: (location: string, from?: number, to?: number) => string; // INCLUDE block handler
-  includeCode?: (location: string, from?: number, to?: number) => string | undefined; // INCLUDECODE block handler
+  frontMatter?: (content: string) => Promise<unknown>; // Custom front matter parser (default: JSON)
+  include?: (location: string, from?: number, to?: number) => Promise<string | undefined>; // INCLUDE block handler
+  includeCode?: (location: string, from?: number, to?: number) => Promise<string | undefined>; // INCLUDECODE block handler
   withSection?: boolean; // Enable section-based rendering (default: false)
   renderTarget?: RenderTarget; // Output format (default: "raw")
 }
@@ -78,9 +78,9 @@ type EmojiRecord =
 class MkImp {
   constructor(options?: MkImpOptions);
 
-  ast(markdown: string): RootToken;      // Generate AST
-  render(root: RootToken): string;       // Render HTML from AST
-  parse(markdown: string): string;       // Directly parse markdown to HTML
+  ast(markdown: string): Promise<RootToken>;  // Generate AST
+  render(root: RootToken): string;            // Render HTML from AST
+  parse(markdown: string): Promise<string>;   // Directly parse markdown to HTML
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mkimp",
-    "version": "0.0.1",
+    "version": "1.0.0",
     "description": "Write markdown like a programmer should be able to",
     "license": "MIT",
     "author": "FriquetLuca",

--- a/src/parser/blocks/index.ts
+++ b/src/parser/blocks/index.ts
@@ -288,7 +288,7 @@ export class BlockTokenizer {
                 this.addToken(token)
                 continue
             } else {
-                this.paragraph()
+                await this.paragraph()
             }
         }
         return this
@@ -438,7 +438,7 @@ export class BlockTokenizer {
             const tokens = await new BlockTokenizer({
                 lexer: this.lexer,
                 lines: this.content.slice(startIndex, this.line),
-            }).tokenize();
+            }).tokenize()
             this.line++
             return {
                 type: "spoiler",
@@ -663,7 +663,7 @@ export class BlockTokenizer {
                 const _tokens = await new BlockTokenizer({
                     lexer: this.lexer,
                     lines,
-                }).tokenize();
+                }).tokenize()
                 const tokens = _tokens.getBlocks()
                 if (tokens.length > 0 && tokens[0].type === "paragraph") {
                     const first = tokens.shift()! as ParagraphToken
@@ -960,7 +960,7 @@ export class BlockTokenizer {
                 const _tokens = await new BlockTokenizer({
                     lexer: this.lexer,
                     lines,
-                }).tokenize();
+                }).tokenize()
                 const tokens = _tokens.getBlocks()
                 this.lexer.footnoteDefs.set(ref, tokens)
             }
@@ -1011,10 +1011,8 @@ export class BlockTokenizer {
                 Math.min(currentHeadingShift + headingShifter, 6)
             )
             this.lexer.started = false
-            const content = await this.lexer.include(includeLocation, from, to);
-            const tokens = content ? await this.lexer.lex(
-                content
-            ) : []
+            const content = await this.lexer.include(includeLocation, from, to)
+            const tokens = content ? await this.lexer.lex(content) : []
             this.lexer.headingShift = currentHeadingShift
             this.lexer.includedLocations.delete(includeLocation)
             this.line++
@@ -1047,7 +1045,8 @@ export class BlockTokenizer {
             try {
                 to = toStr ? Math.max(parseInt(toStr, 10), 1) : undefined
             } catch (_) {}
-            const content = await this.lexer.includeCode(includePath, from, to) ?? raw
+            const content =
+                (await this.lexer.includeCode(includePath, from, to)) ?? raw
             this.line++
             return {
                 type: "codeblock",
@@ -1212,7 +1211,7 @@ export class BlockTokenizer {
                             const item = await new BlockTokenizer({
                                 lexer: this.lexer,
                                 lines: newDef,
-                            }).tokenize();
+                            }).tokenize()
                             definitions.push(item.getBlocks())
                         } else {
                             break

--- a/src/parser/lexer.ts
+++ b/src/parser/lexer.ts
@@ -130,8 +130,8 @@ export class Lexer {
         const _blocks = await new BlockTokenizer({
             lexer: this,
             lines: stringToLines(content, this.tabulation),
-        }).initialize();
-        const blocks = await _blocks.tokenize();
+        }).initialize()
+        const blocks = await _blocks.tokenize()
         return blocks.getBlocks()
     }
     inlineLex(content: string): MdToken[] {
@@ -155,10 +155,11 @@ export class Lexer {
                 includeCode: options?.includeCode,
                 includedLocations: options?.includedLocations,
             })
-        const blocks = await new BlockTokenizer({
+        const _blocks = await new BlockTokenizer({
             lexer,
             lines: stringToLines(content, lexer.tabulation),
-        }).tokenize()
+        }).initialize()
+        const blocks = await _blocks.tokenize()
         const tokens = blocks.getBlocks()
         if (lexer.footnoteDefs.size > 0 && lexer.footnoteIndexMap.size > 1) {
             tokens.push({

--- a/src/parser/mkimp.ts
+++ b/src/parser/mkimp.ts
@@ -6,17 +6,17 @@ export interface MkImpOptions {
     tabulation?: number
     metadata?: Map<string, string>
     emojis?: Record<string, EmojiRecord>
-    frontMatter?: (content: string) => unknown
+    frontMatter?: (content: string) => Promise<unknown>
     include?: (
         location: string,
         from: number | undefined,
         to: number | undefined
-    ) => string
+    ) => Promise<string | undefined>
     includeCode?: (
         location: string,
         from: number | undefined,
         to: number | undefined
-    ) => string | undefined
+    ) => Promise<string | undefined>
     withSection?: boolean
     renderTarget?: RenderTarget
 }
@@ -25,17 +25,17 @@ export class MkImp {
     tabulation: number
     metadata: Map<string, string>
     emojis: Record<string, EmojiRecord>
-    frontMatter?: (content: string) => unknown
+    frontMatter?: (content: string) => Promise<unknown>
     include?: (
         location: string,
         from: number | undefined,
         to: number | undefined
-    ) => string
+    ) => Promise<string | undefined>
     includeCode?: (
         location: string,
         from: number | undefined,
         to: number | undefined
-    ) => string | undefined
+    ) => Promise<string | undefined>
     withSection: boolean
     renderTarget: RenderTarget
     constructor(options: MkImpOptions = {}) {
@@ -48,8 +48,8 @@ export class MkImp {
         this.withSection = options?.withSection ?? false
         this.renderTarget = options?.renderTarget ?? "raw"
     }
-    ast(markdown: string): RootToken {
-        return Lexer.lex(markdown, {
+    async ast(markdown: string): Promise<RootToken> {
+        return await Lexer.lex(markdown, {
             tabulation: this.tabulation,
             metadata: this.metadata,
             emojis: this.emojis,
@@ -65,8 +65,8 @@ export class MkImp {
         })
         return render.render()
     }
-    parse(markdown: string): string {
-        const ast = this.ast(markdown)
+    async parse(markdown: string): Promise<string> {
+        const ast = await this.ast(markdown)
         return this.render(ast)
     }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,8 @@
 import { MkImp } from "../src"
 
 test("frontmatter should be found correctly", async () => {
-    const mkimp = await new MkImp().ast('----\n{\n"hello":"world"\n}\n----\nHello!')
-    const expectResult = new Map([["hello", "world"]])
-    expect(mkimp.metadata).toEqual(expectResult)
+    const mkimp = await new MkImp().ast(
+        '----\n{\n"hello":"world"\n}\n----\nHello!'
+    )
+    expect(mkimp.metadata).toEqual(new Map([["hello", "world"]]))
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { MkImp } from "../src"
 
-test("frontmatter should be found correctly", () => {
-    const mkimp = new MkImp().ast('----\n{\n"hello":"world"\n}\n----\nHello!')
+test("frontmatter should be found correctly", async () => {
+    const mkimp = await new MkImp().ast('----\n{\n"hello":"world"\n}\n----\nHello!')
     const expectResult = new Map([["hello", "world"]])
     expect(mkimp.metadata).toEqual(expectResult)
 })


### PR DESCRIPTION
Change the block tokenizer to be almost fully asynchronous, this is so that we can use include, frontmatter and includeCode asynchronously (for fetching datas for example).